### PR TITLE
Beschlussbeurkundung

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -207,7 +207,7 @@
     Satzungsänderungen, die von Aufsichts-, Gerichts- oder Finanzbehörden aus formalen Gründen verlangt werden, kann der Vorstand von sich aus vornehmen. Diese Satzungsänderungen müssen allen Vereinsmitgliedern alsbald schriftlich mitgeteilt werden.
 
     \Clause{title={Beurkundung von Beschlüssen}}
-    Die in Vorstandssitzungen und in Mitgliederversammlungen erfassten Beschlüsse sind schriftlich niederzulegen und vom Vorstand zu unterzeichnen.
+    Die in Vorstandssitzungen und in Mitgliederversammlungen erfassten Beschlüsse sind schriftlich niederzulegen und vom Vorstandsvorsitz zu unterzeichnen.
 
     \Clause{title={Auflösung des Vereins und Vermögensbindung}}
     Für den Beschluss, den Verein aufzulösen, ist eine 3/4-Mehrheit der in der Mitgliederversammlung anwesenden Mitglieder erforderlich. Der Beschluss kann nur nach rechtzeitiger Ankündigung in der Einladung zur Mitgliederversammlung gefasst werden.


### PR DESCRIPTION
Zur Beurkundung von Beschlüssen ist von nun an lediglich die Unterschrift des Vorstandsvorsitz nötig